### PR TITLE
Implement commands to edit the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,32 @@
-# README
+# Estate Dashboard
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This app enables users to see an overview of their resources and send requests to change their details.
 
-Things you may want to cover:
+## Initial Setup
 
-* Ruby version
+- Ensure Ruby (3.2.2) and Bundler are installed on your device
+- Ensure SQLite is installed on your device (`sqlite3 --version`)
+- Run `bundle install`
+- Run `bin/rails db:migrate`
 
-* System dependencies
+## Operation
 
-* Configuration
+### Hosting the server
+- Run the application with `rails s`
+- By default it will be accessible at `http://localhost:3000/`. This can be changed by adding `-b` and `-p` when running `bin/rails s`. For example `rails s -b 0.0.0.0 -p 4567`
 
-* Database creation
+### Modifying the data
 
-* Database initialization
+Admins with access to the hosting server may make use of the following Rake tasks to modify the database. The terms `rails` and `rake` are interchangeable in the following commands. Some of the commands involve the direct modification of several data fields simultaneously - in this case, the commands will make use of your default text editor, which may be overriden through the `EDITOR` environment variable, e.g. `EDITOR=vim rails orgs:create`.
 
-* How to run the test suite
+#### Organisations
+* `rails orgs:create` - Create a new organisation.
+* `rails orgs:list` - List all organisations.
+* `rails orgs:edit[<org_name>]` - Edit the details of a given organisation.
+* `rails orgs:delete[<org_name>]` - Delete a given organisation.
 
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+#### Resources
+* `rails resources:create[<org_name>]` - Create a new resource for the given organisation.
+* `rails resources:list[<org_name>]` - List all existing resources for the given organisation.
+* `rails resources:edit[<org_name>, <resource_id>]` - Edit the details of a given resource.
+* `rails resources:delete[<org_name>, <resource_id>]` - Delete a given resource.

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,2 @@
+class Organisation < ApplicationRecord
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,8 @@
 class Organisation < ApplicationRecord
   has_many :resources, dependent: :destroy
 
+  validates :name, uniqueness: true
+
   def pretty_display
     "'#{self.name}':\n\tSlack Channel Name: #{self.channel_name}\n\tSlack Channel ID: #{self.channel_id}"
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,5 @@
 class Organisation < ApplicationRecord
+  has_many :resources, dependent: :destroy
 
   def pretty_display
     "'#{self.name}':\n\tSlack Channel Name: #{self.channel_name}\n\tSlack Channel ID: #{self.channel_id}"

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,6 +4,12 @@ class Organisation < ApplicationRecord
   validates :name, uniqueness: true
 
   def pretty_display
-    "'#{self.name}':\n\tSlack Channel Name: #{self.channel_name}\n\tSlack Channel ID: #{self.channel_id}"
+    msg = "'#{self.name}:'"
+    self.attributes.each do |field, value|
+      if !['id', 'created_at', 'updated_at'].include?(field)
+        msg << "\n\t#{field.humanize(keep_id_suffix: true)}: #{value}"
+      end
+    end
+    msg
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,2 +1,6 @@
 class Organisation < ApplicationRecord
+
+  def pretty_display
+    "'#{self.name}':\n\tSlack Channel Name: #{self.channel_name}\n\tSlack Channel ID: #{self.channel_id}"
+  end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,0 +1,2 @@
+class Resource < ApplicationRecord
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,2 +1,3 @@
 class Resource < ApplicationRecord
+  belongs_to :organisation
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,3 +1,13 @@
 class Resource < ApplicationRecord
   belongs_to :organisation
+
+  def pretty_display
+    msg = "Resource ##{self.id}:\n\tOwner: #{Organisation.find(self.organisation_id).name}"
+    self.attributes.each do |field, value|
+      if !['id', 'organisation_id', 'created_at', 'updated_at'].include?(field)
+        msg << "\n\t#{field.humanize(keep_id_suffix: true)}: #{value}"
+      end
+    end
+    msg
+  end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,19 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+module ActiveSupport::Inflector
+  # does the opposite of humanize ... mostly.
+  # Basically does a space-substituting .underscore
+  def dehumanize(the_string)
+    result = the_string.to_s.dup
+    result.downcase.gsub(/ +/,'_')
+  end
+end
+
+class String
+  def dehumanize
+    ActiveSupport::Inflector.dehumanize(self)
+  end
+end
+

--- a/db/migrate/20240604101533_create_organisations.rb
+++ b/db/migrate/20240604101533_create_organisations.rb
@@ -1,6 +1,6 @@
-class CreateOrganisation < ActiveRecord::Migration[7.1]
+class CreateOrganisations < ActiveRecord::Migration[7.1]
   def change
-    create_table :organisation do |t|
+    create_table :organisations do |t|
       t.string :name
       t.string :channel_name
       t.string :channel_id

--- a/db/migrate/20240604102755_create_resources.rb
+++ b/db/migrate/20240604102755_create_resources.rb
@@ -1,7 +1,7 @@
-class CreateResource < ActiveRecord::Migration[7.1]
+class CreateResources < ActiveRecord::Migration[7.1]
   def change
     create_table :resources do |t|
-      t.references :organisation, null: false
+      t.references :organisations, null: false
       t.string :platform
       t.string :resource_class
       t.integer :slot_capacity

--- a/db/migrate/20240604102755_create_resources.rb
+++ b/db/migrate/20240604102755_create_resources.rb
@@ -1,7 +1,7 @@
 class CreateResources < ActiveRecord::Migration[7.1]
   def change
     create_table :resources do |t|
-      t.references :organisations, null: false
+      t.references :organisation, null: false
       t.string :platform
       t.string :resource_class
       t.integer :slot_capacity

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_06_04_102755) do
-  create_table "organisation", force: :cascade do |t|
+  create_table "organisations", force: :cascade do |t|
     t.string "name"
     t.string "channel_name"
     t.string "channel_id"
@@ -20,15 +20,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_102755) do
   end
 
   create_table "resources", force: :cascade do |t|
-    t.integer "organisation_id", null: false
+    t.integer "organisations_id", null: false
     t.string "platform"
     t.string "resource_class"
     t.integer "slot_capacity"
     t.float "cost"
+    t.string "location"
     t.boolean "burst"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["organisation_id"], name: "index_resources_on_organisation_id"
+    t.index ["organisations_id"], name: "index_resources_on_organisations_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_102755) do
   end
 
   create_table "resources", force: :cascade do |t|
-    t.integer "organisations_id", null: false
+    t.integer "organisation_id", null: false
     t.string "platform"
     t.string "resource_class"
     t.integer "slot_capacity"
@@ -29,7 +29,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_102755) do
     t.boolean "burst"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["organisations_id"], name: "index_resources_on_organisations_id"
+    t.index ["organisation_id"], name: "index_resources_on_organisation_id"
   end
 
 end

--- a/lib/tasks/orgs.rake
+++ b/lib/tasks/orgs.rake
@@ -1,15 +1,76 @@
 namespace :orgs do
   editor = ENV['EDITOR'] || "vim"
-  task :create do
-    puts YAML.dump({"test" => "", "test2" => "2"})
+
+  desc "Create a new organisation"
+  task :create => :environment do
+    questions = {}
+    Organisation.columns_hash.values.each do |field|
+      if !['id', 'created_at', 'updated_at'].include?(field.name)
+        questions[field.name.humanize(keep_id_suffix: true)] = nil
+      end
+    end
+    File.write('tmp/org_create.yaml', questions.to_yaml)
+    system(editor, 'tmp/org_create.yaml')
+    answers = YAML.load_file('tmp/org_create.yaml')
+    File.delete('tmp/org_create.yaml')
+    answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h
+    Organisation.create(**answers)
+    puts "Organisation created"
   end
 
-  task :list do
-    puts editor
+  desc "List existing organisations"
+  task :list => :environment do
+    Organisation.find_each do |org|
+      puts org.pretty_display
+    end
   end
 
-  task :edit do
-    system(editor, 'some_temp_file.txt')
+  desc "Edit an organisation"
+  task :edit, [:org_name] => :environment do |t, args|
+    if !args[:org_name]
+      puts "Organisation name is required"
+      next
+    end
+    org = Organisation.find_by(name: args[:org_name])
+    if !org
+      puts "Organisation '#{args[:org_name]}' not found"
+      next
+    end
+    questions = {}
+    org.attributes.each do |field, value|
+      if !['id', 'created_at', 'updated_at'].include?(field)
+        questions[field.humanize(keep_id_suffix: true)] = value
+      end
+    end
+    File.write('tmp/org_edit.yaml', questions.to_yaml)
+    system(editor, 'tmp/org_edit.yaml')
+    answers = YAML.load_file('tmp/org_edit.yaml')
+    File.delete('tmp/org_edit.yaml')
+    answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h
+    org.update(**answers)
+    puts "Details updated"
   end
 
+  desc "Delete an organisation"
+  task :delete, [:org_name] => :environment do |t, args|
+    org_name = args[:org_name]
+    if !org_name
+      puts "Organisation name is required"
+      next
+    end
+    org = Organisation.find_by(name: org_name)
+    if !org
+      puts "Organisation '#{org_name}' not found"
+      next
+    end
+    puts "CAUTION. You are attempting to delete the organisation '#{org_name}'. This action will permanently delete the organisation and all associated resources."
+    print "Continue? (y/N) >"
+    confirm = gets.chomp
+    if confirm.downcase == 'y'
+      org.destroy
+      puts "Organisation '#{org_name}' deleted"
+    else
+      puts "Confirmation not received, deletion aborted."
+    end
+  end
 end

--- a/lib/tasks/orgs.rake
+++ b/lib/tasks/orgs.rake
@@ -1,0 +1,15 @@
+namespace :orgs do
+  editor = ENV['EDITOR'] || "vim"
+  task :create do
+    puts YAML.dump({"test" => "", "test2" => "2"})
+  end
+
+  task :list do
+    puts editor
+  end
+
+  task :edit do
+    system(editor, 'some_temp_file.txt')
+  end
+
+end

--- a/lib/tasks/resources.rake
+++ b/lib/tasks/resources.rake
@@ -1,0 +1,115 @@
+namespace :resources do
+  editor = ENV['EDITOR'] || "vim"
+
+  desc "Create a new resource"
+  task :create, [:org_name] => :environment do |t, args|
+    org_name = args[:org_name]
+    if !org_name
+      puts "Organisation name is required"
+      next
+    end
+    org = Organisation.find_by(name: org_name)
+    if !org
+      puts "Organisation '#{org_name}' not found"
+      next
+    end
+    questions = {}
+    Resource.columns_hash.values.each do |field|
+      if !['id', 'organisation_id', 'created_at', 'updated_at'].include?(field.name)
+        questions[field.name.humanize(keep_id_suffix: true)] = nil
+      end
+    end
+    File.write('tmp/res_create.yaml', questions.to_yaml)
+    system(editor, 'tmp/res_create.yaml')
+    answers = YAML.load_file('tmp/res_create.yaml')
+    File.delete('tmp/res_create.yaml')
+    answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h.merge({ :organisation_id => org.id })
+    Resource.create(**answers)
+    puts "Resource created"
+  end
+
+  desc "List existing resources for a given organisation"
+  task :list, [:org_name] => :environment do |t, args|
+    org_name = args[:org_name]
+    if !org_name
+      puts "Organisation name is required"
+      next
+    end
+    org = Organisation.find_by(name: org_name)
+    if !org
+      puts "Organisation '#{org_name}' not found"
+      next
+    end
+    org.resources.each do |resource|
+      puts resource.pretty_display
+    end
+  end
+
+  desc "Edit a resource"
+  task :edit, [:org_name, :res_id] => :environment do |t, args|
+    if !args[:org_name]
+      puts "Organisation name is required"
+      next
+    end
+    org = Organisation.find_by(name: args[:org_name])
+    if !org
+      puts "Organisation '#{args[:org_name]}' not found"
+      next
+    end
+
+    if !args[:res_id]
+      puts "Resource ID is required"
+      next
+    end
+    resource = org.resources.find_by(id: args[:res_id])
+    if !resource
+      puts "Resource ##{args[:res_id]} not found for organisation '#{org.name}'"
+      next
+    end
+    questions = {}
+    resource.attributes.each do |field, value|
+      if !['id', 'organisation_id', 'created_at', 'updated_at'].include?(field)
+        questions[field.humanize(keep_id_suffix: true)] = value
+      end
+    end
+    File.write('tmp/res_edit.yaml', questions.to_yaml)
+    system(editor, 'tmp/res_edit.yaml')
+    answers = YAML.load_file('tmp/res_edit.yaml')
+    File.delete('tmp/res_edit.yaml')
+    answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h
+    resource.update(**answers)
+  end
+
+  desc "Delete a resource"
+  task :delete, [:org_name, :res_id] => :environment do |t, args|
+    org_name = args[:org_name]
+    if !org_name
+      puts "Organisation name is required"
+      next
+    end
+    org = Organisation.find_by(name: org_name)
+    if !org
+      puts "Organisation '#{org_name}' not found"
+      next
+    end
+
+    if !args[:res_id]
+      puts "Resource ID is required"
+      next
+    end
+    resource = org.resources.find_by(id: args[:res_id])
+    if !resource
+      puts "Resource ##{args[:res_id]} not found for organisation '#{org.name}'"
+      next
+    end
+    puts "CAUTION. You are attempting to delete resource ##{resource.id}. This action is permanent."
+    print "Continue? (y/N) >"
+    confirm = gets.chomp
+    if confirm.downcase == 'y'
+      resource.destroy
+      puts "Resource ##{resource.id} deleted"
+    else
+      puts "Confirmation not received, deletion aborted."
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces commands that allow admins to edit the database. These implement typical CRUD commands for the `Organisation` and `Resource` table. To supplement these commands, some new functions are included in this PR too:

* A `pretty_display` function for `Organisation` and `Resource` records, allowing their data to be formatted into a human-readable context.
* A `dehumanize` function. This function exists to invert the existing `humanize` function provided by Rails, which converts strings into a human readable format. For example, `"channel_name".humanize` becomes `"Channel Name"`. The new `dehumanize` function provided in this PR reverses this process.

This PR also includes a proper README for the application, which includes specific usage of each of the new commands.