### PR TITLE
Allow users to send change requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+gem "faraday"
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,10 @@ GEM
       reline (>= 0.3.8)
     drb (2.2.1)
     erubi (1.12.0)
+    faraday (2.9.1)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -130,6 +134,8 @@ GEM
     minitest (5.23.1)
     msgpack (1.7.2)
     mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.12)
       date
       net-protocol
@@ -219,6 +225,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (0.13.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -240,6 +247,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  faraday
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This app enables users to see an overview of their resources and send requests t
 - Ensure Ruby (3.2.2) and Bundler are installed on your device
 - Ensure SQLite is installed on your device (`sqlite3 --version`)
 - Run `bundle install`
+- Update the application's database credentials using `EDITOR=vim rails credentials:edit` (replacing `vim` with the editor of your choice) and setting:
+  - `slack_token` - Set this to the token for the Slack bot you are using. This token will start with `xoxb-`. The bot must have permission to send messages to the desired channel, and must be invited to the channel first. Alces Flight admins should use Estate DashBot's token for this field, which is available on request.
 - Run `bin/rails db:migrate`
 
 ## Operation

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ Admins with access to the hosting server may make use of the following Rake task
 
 #### Requests
 * `rails requests:list` - List past change requests from users
+
+#### Changes
+* `rails changes:list` - List past changes made to resources. These logs reflect changes made using the above Rake commands - any changes made internally by the app or through use of `rails console` will not be stored here.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ Admins with access to the hosting server may make use of the following Rake task
 * `rails resources:list[<org_name>]` - List all existing resources for the given organisation.
 * `rails resources:edit[<org_name>, <resource_id>]` - Edit the details of a given resource.
 * `rails resources:delete[<org_name>, <resource_id>]` - Delete a given resource.
+
+#### Requests
+* `rails requests:list` - List past change requests from users

--- a/app/controllers/organisation_controller.rb
+++ b/app/controllers/organisation_controller.rb
@@ -7,7 +7,7 @@ class OrganisationController < ApplicationController
   def send_message
     org = Organisation.find(params["org_id"])
     res = org.resources.find_by(id: params["resource_id"])
-    change_request = ChangeRequest.create(resource_id: res.id)
+    change_request = ChangeRequest.new(resource_id: res.id)
 
     msg = ""
     params.each do |key, value|
@@ -16,9 +16,7 @@ class OrganisationController < ApplicationController
         msg << "\n\t*#{key.humanize(keep_id_suffix: true)}:* #{res[key]} -> *#{value}*"
       end
     end
-    if msg.blank?
-      puts "No changes requested"
-    else
+    if !msg.blank?
       msg = "-" * 30 + "\nChange request received from *#{org.name}* for *resource ##{res.id}*:" + msg
       org.send_message(msg)
       change_request.save

--- a/app/controllers/organisation_controller.rb
+++ b/app/controllers/organisation_controller.rb
@@ -7,10 +7,12 @@ class OrganisationController < ApplicationController
   def send_message
     org = Organisation.find(params["org_id"])
     res = org.resources.find_by(id: params["resource_id"])
+    change_request = ChangeRequest.create(resource_id: res.id)
 
     msg = ""
     params.each do |key, value|
       if !['resource_id', 'controller', 'action', 'org_id'].include?(key) && (res[key].to_s != value) && !value.blank?
+        change_request[key] = value
         msg << "\n\t*#{key.humanize(keep_id_suffix: true)}:* #{res[key]} -> *#{value}*"
       end
     end
@@ -19,6 +21,7 @@ class OrganisationController < ApplicationController
     else
       msg = "-" * 30 + "\nChange request received from *#{org.name}* for *resource ##{res.id}*:" + msg
       org.send_message(msg)
+      change_request.save
     end
   end
 

--- a/app/controllers/organisation_controller.rb
+++ b/app/controllers/organisation_controller.rb
@@ -1,0 +1,25 @@
+class OrganisationController < ApplicationController
+
+  def show
+    @org = Organisation.find_by(name: params[:org_name])
+  end
+
+  def send_message
+    org = Organisation.find(params["org_id"])
+    res = org.resources.find_by(id: params["resource_id"])
+
+    msg = ""
+    params.each do |key, value|
+      if !['resource_id', 'controller', 'action', 'org_id'].include?(key) && (res[key].to_s != value) && !value.blank?
+        msg << "\n\t*#{key.humanize(keep_id_suffix: true)}:* #{res[key]} -> *#{value}*"
+      end
+    end
+    if msg.blank?
+      puts "No changes requested"
+    else
+      msg = "-" * 30 + "\nChange request received from *#{org.name}* for *resource ##{res.id}*:" + msg
+      org.send_message(msg)
+    end
+  end
+
+end

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -1,0 +1,13 @@
+class Change < ApplicationRecord
+  belongs_to :resource
+
+  def pretty_display
+    msg = ""
+    self.attributes.each do |field, value|
+      if !['id', 'resource_id', 'org_id', 'created_at', 'updated_at'].include?(field) && value
+        msg << "\n\tSet #{field.humanize(keep_id_suffix: true)} to #{value}"
+      end
+    end
+    msg = "#{self.created_at}: Change applied for resource ##{self.resource_id}:" + msg
+  end
+end

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -4,7 +4,7 @@ class ChangeRequest < ApplicationRecord
   def pretty_display
     msg = ""
     self.attributes.each do |field, value|
-      if !['resource_id', 'org_id', 'created_at', 'updated_at'].include?(field) && value
+      if !['id', 'resource_id', 'org_id', 'created_at', 'updated_at'].include?(field) && value
         msg << "\n\tSet #{field.humanize(keep_id_suffix: true)} to #{value}"
       end
     end

--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -1,0 +1,13 @@
+class ChangeRequest < ApplicationRecord
+  belongs_to :resource
+
+  def pretty_display
+    msg = ""
+    self.attributes.each do |field, value|
+      if !['resource_id', 'org_id', 'created_at', 'updated_at'].include?(field) && value
+        msg << "\n\tSet #{field.humanize(keep_id_suffix: true)} to #{value}"
+      end
+    end
+    msg = "#{self.created_at}: Change request received for resource ##{self.resource_id}:" + msg
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,4 +6,8 @@ class Organisation < ApplicationRecord
   def pretty_display
     "'#{self.name}':\n\tSlack Channel Name: #{self.channel_name}\n\tSlack Channel ID: #{self.channel_id}"
   end
+
+  def send_message(msg)
+    Slack.send_message(self.channel_id, msg)
+  end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -2,6 +2,10 @@ class Resource < ApplicationRecord
   belongs_to :organisation
   has_many :change_requests, dependent: :destroy
 
+  validates :platform, :resource_class, :location, presence: true
+  validates :slot_capacity, numericality: { only_integer: true }
+  validates :cost, numericality: true
+
   def pretty_display
     msg = "Resource ##{self.id}:\n\tOwner: #{Organisation.find(self.organisation_id).name}"
     self.attributes.each do |field, value|

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,5 +1,6 @@
 class Resource < ApplicationRecord
   belongs_to :organisation
+  has_many :change_requests, dependent: :destroy
 
   def pretty_display
     msg = "Resource ##{self.id}:\n\tOwner: #{Organisation.find(self.organisation_id).name}"

--- a/app/views/organisation/show.html.erb
+++ b/app/views/organisation/show.html.erb
@@ -1,0 +1,16 @@
+<h1><%= "Page for #{@org.name}"%></h1>
+
+<h2>Modify an existing resource:</h2>
+<form action="/send-message" method="post">
+  <input type="hidden" name="org_id" value=<%= "#{@org.id}" %> />
+  Resource ID: <input type="text" name="resource_id"> <br>
+  <% Resource.columns_hash.values.each do |field| %>
+  <%   if !['id', 'organisation_id', 'created_at', 'updated_at'].include?(field.name) %>
+         <% display_name = field.name.humanize(keep_id_suffix: true).ljust(100, ' ') %>
+         <%= "#{display_name}:" %> <input type="text" name="<%= field.name %>">
+         <br>
+  <%   end %>
+  <% end %>
+
+  <input type="submit" value="Submit">
+</form>

--- a/app/views/organisation/show.html.erb
+++ b/app/views/organisation/show.html.erb
@@ -1,16 +1,36 @@
 <h1><%= "Page for #{@org.name}"%></h1>
 
 <h2>Modify an existing resource:</h2>
-<form action="/send-message" method="post">
-  <input type="hidden" name="org_id" value=<%= "#{@org.id}" %> />
-  Resource ID: <input type="text" name="resource_id"> <br>
-  <% Resource.columns_hash.values.each do |field| %>
-  <%   if !['id', 'organisation_id', 'created_at', 'updated_at'].include?(field.name) %>
-         <% display_name = field.name.humanize(keep_id_suffix: true).ljust(100, ' ') %>
-         <%= "#{display_name}:" %> <input type="text" name="<%= field.name %>">
-         <br>
-  <%   end %>
-  <% end %>
+<table>
+  <form action="/send-message" method="post">
+    <input type="hidden" name="org_id" value=<%= "#{@org.id}" %> />
+    <tr>
+      <td> Resource ID: </td>
+      <td>
+        <select name="resource_id">
+          <% @org.resources.each do |res| %>
+            <option value= <%= res.id %>> <%= "##{res.id}" %> </option>
+          <% end %>
+        </select>
+      </td>
+    </tr>
+    <% Resource.columns_hash.values.each do |field| %>
+      <tr>
+        <% if !['id', 'organisation_id', 'created_at', 'updated_at', 'cost', 'burst'].include?(field.name) %>
+          <% display_name = field.name.humanize(keep_id_suffix: true) %>
+          <td> <%= "#{display_name}:" %> </td>
+          <td><input type="text" name="<%= field.name %>"></td>
+        <% end %>
+      </tr>
+    <% end %>
+    <td> Usage: </td>
+    <td>
+      <select name="burst">
+        <option value= false> Dedicated </option>
+        <option value= true> Burst </option>
+      </select> <br>
+    </td>
 
-  <input type="submit" value="Submit">
-</form>
+    <tr><td colspan="2"><input type="submit" value="Submit request" style="height:35px; width:300px"></td></tr>
+  </form>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   root "home#index"
+
+  get "org/:org_name",  to: "organisation#show"
+  post "send-message/", to: "organisation#send_message"
 end

--- a/db/migrate/20240607164431_create_change_requests.rb
+++ b/db/migrate/20240607164431_create_change_requests.rb
@@ -1,0 +1,14 @@
+class CreateChangeRequests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :change_requests do |t|
+      t.references :resource, null: false
+      t.string :platform
+      t.string :resource_class
+      t.integer :slot_capacity
+      t.string :location
+      t.boolean :burst
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240611101638_create_changes.rb
+++ b/db/migrate/20240611101638_create_changes.rb
@@ -1,0 +1,14 @@
+class CreateChanges < ActiveRecord::Migration[7.1]
+  def change
+    create_table :changes do |t|
+      t.references :resource, null: false
+      t.string :platform
+      t.string :resource_class
+      t.integer :slot_capacity
+      t.string :location
+      t.boolean :burst
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_07_164431) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_11_101638) do
   create_table "change_requests", force: :cascade do |t|
     t.integer "resource_id", null: false
     t.string "platform"
@@ -21,6 +21,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_07_164431) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["resource_id"], name: "index_change_requests_on_resource_id"
+  end
+
+  create_table "changes", force: :cascade do |t|
+    t.integer "resource_id", null: false
+    t.string "platform"
+    t.string "resource_class"
+    t.integer "slot_capacity"
+    t.string "location"
+    t.boolean "burst"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resource_id"], name: "index_changes_on_resource_id"
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_04_102755) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_07_164431) do
+  create_table "change_requests", force: :cascade do |t|
+    t.integer "resource_id", null: false
+    t.string "platform"
+    t.string "resource_class"
+    t.integer "slot_capacity"
+    t.string "location"
+    t.boolean "burst"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resource_id"], name: "index_change_requests_on_resource_id"
+  end
+
   create_table "organisations", force: :cascade do |t|
     t.string "name"
-    t.string "channel_name"
     t.string "channel_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "channel_name"
   end
 
   create_table "resources", force: :cascade do |t|

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -1,0 +1,22 @@
+class Slack
+  require 'faraday'
+  SLACK_TOKEN = Rails.application.credentials.slack_token
+
+  def self.slack
+    @slack ||= Faraday.new('https://slack.com/api/') 
+  end
+
+  def self.send_message(channel_id, msg)
+    response = slack.post('chat.postMessage') do |req|
+      req.headers[:content_type] = 'application/json'
+      req.headers["Authorization"] = "Bearer #{SLACK_TOKEN}"
+      req.headers[:charset] = 'text/plain'
+      req.body = JSON.generate(
+        {
+          "text" => msg,
+          "channel" => channel_id
+        }
+      )
+    end
+  end
+end

--- a/lib/tasks/changes.rake
+++ b/lib/tasks/changes.rake
@@ -1,0 +1,10 @@
+namespace :changes do
+
+  desc "List past changes to resources"
+  task :list => :environment do
+    Change.find_each do |change|
+      puts change.pretty_display
+    end
+  end
+
+end

--- a/lib/tasks/requests.rake
+++ b/lib/tasks/requests.rake
@@ -1,0 +1,10 @@
+namespace :requests do
+
+  desc "List past change requests"
+  task :list => :environment do
+    ChangeRequest.find_each do |req|
+      puts req.pretty_display
+    end
+  end
+
+end

--- a/lib/tasks/resources.rake
+++ b/lib/tasks/resources.rake
@@ -25,8 +25,8 @@ namespace :resources do
     File.delete('tmp/res_create.yaml')
 
     answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h
-    resource = Resource.create(**(answers.merge({ :organisation_id => org.id })))
-    Change.create(**(answers.merge({ :resource_id => resource.id })))
+    resource = Resource.create!(**(answers.merge({ :organisation_id => org.id })))
+    Change.create!(**(answers.merge({ :resource_id => resource.id })))
     puts "Resource created"
   end
 
@@ -81,8 +81,8 @@ namespace :resources do
 
     answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h
     changes = (answers.merge({ :resource_id => resource.id }).to_a - resource.attributes.map{ |k, v| [k.to_sym, v] }).to_h
-    Change.create(**changes)
-    resource.update(**answers)
+    Change.create!(**changes)
+    resource.update!(**answers)
     puts "Resource modified"
   end
 

--- a/lib/tasks/resources.rake
+++ b/lib/tasks/resources.rake
@@ -23,8 +23,10 @@ namespace :resources do
     system(editor, 'tmp/res_create.yaml')
     answers = YAML.load_file('tmp/res_create.yaml')
     File.delete('tmp/res_create.yaml')
-    answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h.merge({ :organisation_id => org.id })
-    Resource.create(**answers)
+
+    answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h
+    resource = Resource.create(**(answers.merge({ :organisation_id => org.id })))
+    Change.create(**(answers.merge({ :resource_id => resource.id })))
     puts "Resource created"
   end
 
@@ -76,8 +78,12 @@ namespace :resources do
     system(editor, 'tmp/res_edit.yaml')
     answers = YAML.load_file('tmp/res_edit.yaml')
     File.delete('tmp/res_edit.yaml')
+
     answers = answers.map { |k, v| [k.dehumanize.to_sym, v] }.to_h
+    changes = (answers.merge({ :resource_id => resource.id }).to_a - resource.attributes.map{ |k, v| [k.to_sym, v] }).to_h
+    Change.create(**changes)
     resource.update(**answers)
+    puts "Resource modified"
   end
 
   desc "Delete a resource"


### PR DESCRIPTION
Note: This branch is based on the branch used in PR #1. It should not be merged before that PR.

This PR enables users to send their own change requests. These requests will be sent into the Slack channel specified in the data for that Organisation. This requires a Slack bot token, which is a secret token given on the page for your slack bot (this code should start with `xoxb-`). This token is entered using the `rails credentials:edit` command.

The intention is for a single slack bot to perform all the messaging, although technically that isn't required. I created "Flight DashBot" for this purpose, although I can't publicly share the token as part of this PR. If a different bot is created/used, it will of course need to be added to the workspace, given permission to send messages, and invited to the channel it's intended to send messages to.

Each request will also generate an entry in the `ChangeRequests` table which logs each field that was changed and the time the change was made. A similar logging system also exists for changes actually made to the database using the existing Rake commands - the `Changes` table stores these changes. New Rake commands were added which list each of these log entries.